### PR TITLE
2021-06-09 ROYAL-1833 Changed content type from FormUrlEncoded to Json

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <AssemblyVersion>1.2.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Services/BaseService.cs
+++ b/src/EtsyAccess/Services/BaseService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CuttingEdge.Conditions;
@@ -208,7 +209,8 @@ namespace EtsyAccess.Services
 				return new ActionPolicy( Config.RetryAttempts )
 					.ExecuteAsync(async () =>
 						{
-							var content = new FormUrlEncodedContent( payload );
+							var stringPayload = JsonConvert.SerializeObject( payload );
+							var content = new StringContent( stringPayload, Encoding.UTF8, "application/json" );
 
 							if ( !url.Contains( Config.ApiBaseUrl ) )
 								url = Config.ApiBaseUrl + url;


### PR DESCRIPTION
Changed content type from FormUrlEncoded to Json (solved an issue with the "Invalid URI: The Uri string is too long." exception for listings with big amount of variations as FormUrlEncodedContent has a limit)