### PR TITLE
2021-10-28 GUARD-2216 Increased timeout to prevent kill running tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ build
 log
 *Credentials*.csv
 
+#Rider
+src/.idea/

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <Version>1.2.1</Version>
+    <Version>1.3.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,7 +11,7 @@
     <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.2.2.0</AssemblyVersion>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Models/Configuration/EtsyConfig.cs
+++ b/src/EtsyAccess/Models/Configuration/EtsyConfig.cs
@@ -48,7 +48,7 @@ namespace EtsyAccess.Models.Configuration
 		/// </summary>
 		public readonly int ThrottlingMaxRetryAttempts = 10;
 
-		public EtsyConfig( string shopName, string token, string tokenSecret, int requestTimeoutMs = 30 * 1000 )
+		public EtsyConfig( string shopName, string token, string tokenSecret, int requestTimeoutMs = 5 * 60 * 1000 )
 		{
 			Condition.Requires( shopName ).IsNotNullOrEmpty();
 			Condition.Requires( token ).IsNotNullOrEmpty();

--- a/src/EtsyAccess/Models/Configuration/EtsyConfig.cs
+++ b/src/EtsyAccess/Models/Configuration/EtsyConfig.cs
@@ -48,7 +48,7 @@ namespace EtsyAccess.Models.Configuration
 		/// </summary>
 		public readonly int ThrottlingMaxRetryAttempts = 10;
 
-		public EtsyConfig( string shopName, string token, string tokenSecret, int requestTimeoutMs = 5 * 60 * 1000 )
+		public EtsyConfig( string shopName, string token, string tokenSecret, int requestTimeoutMs = 5 * 60 * 1000 ) // Default timeout 5min. 
 		{
 			Condition.Requires( shopName ).IsNotNullOrEmpty();
 			Condition.Requires( token ).IsNotNullOrEmpty();

--- a/src/EtsyAccess/Services/BaseService.cs
+++ b/src/EtsyAccess/Services/BaseService.cs
@@ -96,7 +96,9 @@ namespace EtsyAccess.Services
 			if ( cancellationToken.IsCancellationRequested )
 			{
 				var exceptionDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
-				throw new EtsyException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+				
+				//See CancelAfter() for timeout
+				throw new EtsyException( string.Format( "{0}. Task was cancelled or timed out (timeout limit - {1}ms)", exceptionDetails, Config.RequestTimeoutMs ) );
 			}
 
 			var responseContent = await Throttler.ExecuteAsync(() =>
@@ -147,7 +149,9 @@ namespace EtsyAccess.Services
 			if ( cancellationToken.IsCancellationRequested )
 			{
 				var exceptionDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
-				throw new EtsyException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+				
+				//See CancelAfter() for timeout
+				throw new EtsyException( string.Format( "{0}. Task was cancelled or timed out (timeout limit - {1}ms)", exceptionDetails, Config.RequestTimeoutMs ) );
 			}
 
 			var responseContent = await Throttler.ExecuteAsync(() =>
@@ -201,7 +205,9 @@ namespace EtsyAccess.Services
 			if ( token.IsCancellationRequested )
 			{
 				var exceptionDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
-				throw new EtsyException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+
+				//See CancelAfter() for timeout
+				throw new EtsyException( string.Format( "{0}. Task was cancelled or timed out (timeout limit - {1}ms)", exceptionDetails, Config.RequestTimeoutMs ) );
 			}
 
 			return Throttler.ExecuteAsync(() =>
@@ -253,7 +259,9 @@ namespace EtsyAccess.Services
 			if ( token.IsCancellationRequested )
 			{
 				var exceptionDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
-				throw new EtsyException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+				
+				//See CancelAfter() for timeout
+				throw new EtsyException( string.Format( "{0}. Task was cancelled or timed out (timeout limit - {1}ms)", exceptionDetails, Config.RequestTimeoutMs ) );
 			}
 
 			return Throttler.ExecuteAsync(() =>

--- a/src/EtsyAccessTests/BaseTest.cs
+++ b/src/EtsyAccessTests/BaseTest.cs
@@ -53,7 +53,7 @@ namespace EtsyAccessTests
 		{
 			string path = new Uri( Path.GetDirectoryName( Assembly.GetExecutingAssembly().CodeBase ) ).LocalPath;
 
-			using( var reader = new StreamReader( path + @"\..\..\credentials.csv" ) )
+			using( var reader = new StreamReader( path + @"\..\..\files\credentials.csv" ) )
 			{
 				return new TestCredentials()
 				{

--- a/src/EtsyAccessTests/ItemsServiceTests.cs
+++ b/src/EtsyAccessTests/ItemsServiceTests.cs
@@ -66,10 +66,11 @@ namespace EtsyAccessTests
 			var listing = this.EtsyItemsService.GetListingsBySkus( new List<string> { Sku }, CancellationToken.None ).Result.ToList();
 
 			Assert.IsTrue( listing.Any() );
-			Assert.AreEqual( Sku, listing[0].Sku[0] );
+			Assert.Contains( Sku, listing[0].Sku );
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateSkuQuantity()
 		{
 			int quantity = 12;
@@ -85,6 +86,7 @@ namespace EtsyAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateSkuQuantityToZero()
 		{
 			int quantity = 0;
@@ -100,6 +102,7 @@ namespace EtsyAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateSkuQuantityWithQuoteInTheOptionName()
 		{
 			int quantity = 2;
@@ -116,6 +119,7 @@ namespace EtsyAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		public void UpdateSkusQuantities()
 		{
 			string sku = "testSku1";
@@ -146,6 +150,7 @@ namespace EtsyAccessTests
 		}
 
 		[ Test ]
+		[ Explicit ]
 		// This will take awhile
 		public void UpdateSkusQuantities_Over30Variations_ShouldUpdateThem()
 		{


### PR DESCRIPTION
[GUARD-2216](https://agileharbor.atlassian.net/browse/GUARD-2216)

I was not able to reproduce exactly the same scenario from the ticket... I tried to use the method which most fails a hundred times the same way that happens in a real scenario, but the tests have passed with no problem.

Note: We're not exceeding the limit rate of using Etsy API also

In discussion with the team, we decided to increase the timeout by 5 minutes and do some regression tests. 

Note: The file ItemsServiceTests.cs was affected with git difference bug.

My only code changes in ItemsServiceTests.cs:

- Adding [ Explicit ] to methods which push changes to Etsy
- Changed the Assert expression from method  GetListingsBySkus() From [This](https://github.com/skuvault-integrations/etsyAccess/compare/GUARD-2216-Throttling_errors_Etsy_full_inventory_sync?expand=1#diff-59dfc8de11d435e479b312f9fd618bb82fd30f341131a286c1d7dc2d32d2fd80L69) To [This](https://github.com/skuvault-integrations/etsyAccess/compare/GUARD-2216-Throttling_errors_Etsy_full_inventory_sync?expand=1#diff-59dfc8de11d435e479b312f9fd618bb82fd30f341131a286c1d7dc2d32d2fd80R69)