### PR TITLE
ROLEX-2719 - Etsy Full Inventory Sync is failing with A Task was canceled Error

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+# Description
+
+Tickets: [JIRA-1234] (Replace with appropriate tickets. Some automations depend on this section, don't remove)
+
+Summary of your changes, with screenshots if appropriate.
+Help us understand what you did. Describe how the code works and why it was done this way. You can also leave comments directly in the changed files to provide direct explanation, but check if it would be more appropriate to add those comments as inline comments in the code.
+
+## Type of change (should only be one)
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
+- [ ] Configuration change
+- [ ] New / updated script
+- [ ] Refactoring
+- [ ] New tests to existing code
+
+Additional changes:
+- [ ] Confluence documentation updated - [link]
+
+# Additional Notes
+
+List things that we need to be aware of.
+* If these changes depend on a set of other changes in another repository or a pull request.
+* If your code has any known issues that are not being resolved as part of these changes, list them here.
+  Remove this section if no additional notes.
+
+# PR Readiness Checklist
+
+Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it.
+
+- [ ] Followed [development conventions][1] to the best of my ability
+- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
+- [ ] Tests are updated / added and all pass
+- [ ] Performed a self-review of my own code
+- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
+- [ ] Confluence documentation is updated, if needed
+- [ ] New code does not generate new warnings
+- [ ] Formatted new code, according to the applicable rules
+
+[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
-    <Version>1.7.4.0</Version>
+    <Version>1.7.5</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,9 +11,9 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/etsyAccess</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/etsyAccess</RepositoryUrl>
-    <AssemblyVersion>1.7.5.1</AssemblyVersion>
-    <FileVersion>1.7.5.1</FileVersion>
-    <PackageVersion>1.7.5-alpha.1</PackageVersion>
+    <AssemblyVersion>1.7.5.2</AssemblyVersion>
+    <FileVersion>1.7.5.2</FileVersion>
+    <PackageVersion>1.7.5</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -8,11 +8,12 @@
     <Authors>SkuVault</Authors>
     <Description>Etsy webservices API wrapper</Description>
     <Copyright>SkuVault © 2020</Copyright>
-    <PackageProjectUrl>https://github.com/skuvault/etsyAccess/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/skuvault/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
-    <RepositoryUrl>https://github.com/skuvault/etsyAccess/</RepositoryUrl>
-    <AssemblyVersion>1.7.4.0</AssemblyVersion>
-    <FileVersion>1.7.4.0</FileVersion>
+    <PackageProjectUrl>https://github.com/skuvault-integrations/etsyAccess</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/skuvault-integrations/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/skuvault-integrations/etsyAccess</RepositoryUrl>
+    <AssemblyVersion>1.7.5.1</AssemblyVersion>
+    <FileVersion>1.7.5.1</FileVersion>
+    <PackageVersion>1.7.5-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Exceptions/EtsyException.cs
+++ b/src/EtsyAccess/Exceptions/EtsyException.cs
@@ -65,4 +65,12 @@ namespace EtsyAccess.Exceptions
 	{
 		public EtsyBadGatewayException( string message ) : base( message, 502 ) { }
 	}
+
+	/// <summary>
+	///	502 Bad Gateway exception the Etsy api occasionally returns. Retry the request when this happens
+	/// </summary>
+	public class EtsyConflictException : EtsyServerException
+	{
+		public EtsyConflictException( string message ) : base( message, 409 ) { }
+	}
 }

--- a/src/EtsyAccess/Exceptions/EtsyException.cs
+++ b/src/EtsyAccess/Exceptions/EtsyException.cs
@@ -67,7 +67,7 @@ namespace EtsyAccess.Exceptions
 	}
 
 	/// <summary>
-	///	502 Bad Gateway exception the Etsy api occasionally returns. Retry the request when this happens
+	///	409 Conflict exception the Etsy api occasionally returns. Retry the request when this happens
 	/// </summary>
 	public class EtsyConflictException : EtsyServerException
 	{

--- a/src/EtsyAccess/Models/Throttling/ActionPolicy.cs
+++ b/src/EtsyAccess/Models/Throttling/ActionPolicy.cs
@@ -46,7 +46,7 @@ namespace EtsyAccess.Models.Throttling
 					catch ( TaskCanceledException ex )
 					{
 						var exceptionDetails = extraLogInfo != null ? extraLogInfo() : string.Empty;
-						if( ex.CancellationToken == cancellationToken )
+						if ( ex.CancellationToken == cancellationToken )
 						{
 							// a real cancellation, triggered by the caller
 							throw new EtsyException( exceptionDetails, ex );

--- a/src/EtsyAccess/Services/Items/EtsyItemsService.cs
+++ b/src/EtsyAccess/Services/Items/EtsyItemsService.cs
@@ -190,7 +190,7 @@ namespace EtsyAccess.Services.Items
 				var listingInventory = await GetListingInventoryAsync( listing, token, mark ).ConfigureAwait( false );
 
 				if ( listingInventory != null )
-					await UpdateSkuQuantityAsync( listing, listingInventory, sku, quantity, token, mark );
+					await UpdateSkuQuantityAsync( listing, listingInventory, sku, quantity, token, mark ).ConfigureAwait( false );
 			}
 		}
 
@@ -232,8 +232,8 @@ namespace EtsyAccess.Services.Items
 			var listing = listings.FirstOrDefault();
 			
 			// get listing's product inventory
-			if (listing != null)
-				listingInventory = await GetListingInventoryAsync( listing, token );
+			if ( listing != null )
+				listingInventory = await GetListingInventoryAsync( listing, token ).ConfigureAwait( false );
 
 			return listingInventory;
 		}

--- a/src/EtsyAccess/Shared/EtsyLogger.cs
+++ b/src/EtsyAccess/Shared/EtsyLogger.cs
@@ -67,7 +67,7 @@ namespace EtsyAccess.Shared
 
 		public static void LogTraceRetryStarted( int delaySeconds, int attempt, string info )
 		{
-			info = String.Format( "{0}, Delay: {0}s, Attempt: {1} ", info, delaySeconds, attempt );
+			info = $"{info}, Delay: {delaySeconds}s, Attempt: {attempt} ";
 			TraceLog( "Trace info", info );
 		}
 


### PR DESCRIPTION
# Description

Tickets: [ROLEX-2719]

Etsy's Full Inventory Sync keeps failing with A Task Was Canceled error.

To fix the issue, I:
- changed RequestTimeout implementation:
it was: linkedTokenSource.CancelAfter( Config.RequestTimeoutMs )
now: httpClient.Timeout
- added TaskCanceledException to the retry logic. Will retry request if it fails with the Request timeout error.


## Type of change (should only be one)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code


# PR Readiness Checklist

Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it.

- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings
- [x] Formatted new code, according to the applicable rules

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions

[ROLEX-2719]: https://agileharbor.atlassian.net/browse/ROLEX-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ