### PR TITLE
ROLEX-2719 Fix the ArgumentOutOfRangeException when default etsyConfig (with RequestTimeoutMs = 0) is used

### DIFF
--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -11,9 +11,9 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/etsyAccess</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/etsyAccess</RepositoryUrl>
-    <AssemblyVersion>1.7.6.1</AssemblyVersion>
-    <FileVersion>1.7.6.1</FileVersion>
-    <PackageVersion>1.7.6-alpha.1</PackageVersion>
+    <AssemblyVersion>1.7.6.2</AssemblyVersion>
+    <FileVersion>1.7.6.2</FileVersion>
+    <PackageVersion>1.7.6</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/EtsyAccess.csproj
+++ b/src/EtsyAccess/EtsyAccess.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>SkuVault</Company>
     <Authors>SkuVault</Authors>
@@ -11,9 +11,9 @@
     <PackageProjectUrl>https://github.com/skuvault-integrations/etsyAccess</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/skuvault-integrations/etsyAccess/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/skuvault-integrations/etsyAccess</RepositoryUrl>
-    <AssemblyVersion>1.7.5.2</AssemblyVersion>
-    <FileVersion>1.7.5.2</FileVersion>
-    <PackageVersion>1.7.5</PackageVersion>
+    <AssemblyVersion>1.7.6.1</AssemblyVersion>
+    <FileVersion>1.7.6.1</FileVersion>
+    <PackageVersion>1.7.6-alpha.1</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EtsyAccess/Services/BaseService.cs
+++ b/src/EtsyAccess/Services/BaseService.cs
@@ -51,9 +51,13 @@ namespace EtsyAccess.Services
 
 			HttpClient = new HttpClient()
 			{
-				BaseAddress = new Uri( Config.ApiBaseUrl ),
-				Timeout = TimeSpan.FromMilliseconds( config.RequestTimeoutMs )
+				BaseAddress = new Uri( Config.ApiBaseUrl )
 			};
+
+			if ( config.RequestTimeoutMs > 0 )
+			{
+				HttpClient.Timeout = TimeSpan.FromMilliseconds( config.RequestTimeoutMs );
+			}
 
 			SetSslSettings();
 


### PR DESCRIPTION
# Description

Tickets: [ROLEX-2719] 

In this PR: 
https://github.com/skuvault-integrations/etsyAccess/pull/38/files#diff-5ea577b9b11de3cc80ef8c51586027b3ac6c822397dc1c567fef95e5504d34e4R55
I set the httpClient.Timeout property with the value from etsyConfig.
It turned out in some places we are using default (parameterless) config and the RequestTimeoutMs prop in this case is zero. It causes ArgumentOutOfRangeException 

## Type of change (should only be one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code


# PR Readiness Checklist

Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it.

- [ ] Followed [development conventions][1] to the best of my ability
- [ ] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [ ] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [ ] New code does not generate new warnings
- [ ] Formatted new code, according to the applicable rules

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions

[ROLEX-2719]: https://agileharbor.atlassian.net/browse/ROLEX-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ